### PR TITLE
Add Max Metric to Webreport

### DIFF
--- a/jplag/src/main/java/de/jplag/options/SimilarityMetric.java
+++ b/jplag/src/main/java/de/jplag/options/SimilarityMetric.java
@@ -3,21 +3,28 @@ package de.jplag.options;
 import java.util.function.Function;
 
 import de.jplag.JPlagComparison;
+import de.jplag.Messages;
 
 public enum SimilarityMetric implements Function<JPlagComparison, Float> {
-    AVG(JPlagComparison::similarity),
-    MIN(JPlagComparison::minimalSimilarity),
-    MAX(JPlagComparison::maximalSimilarity),
-    INTERSECTION(it -> (float) it.getNumberOfMatchedTokens());
+    AVG(JPlagComparison::similarity, Messages.getString("SimilarityMetric.Avg.Description")),
+    MIN(JPlagComparison::minimalSimilarity, "MIN"),
+    MAX(JPlagComparison::maximalSimilarity, Messages.getString("SimilarityMetric.Max.Description")),
+    INTERSECTION(it -> (float) it.getNumberOfMatchedTokens(), "Intersection");
 
     private final Function<JPlagComparison, Float> similarityFunction;
+    private final String description;
 
-    SimilarityMetric(Function<JPlagComparison, Float> determinePercentage) {
+    SimilarityMetric(Function<JPlagComparison, Float> determinePercentage, String description) {
         this.similarityFunction = determinePercentage;
+        this.description = description;
     }
 
     public boolean isAboveThreshold(JPlagComparison comparison, float similarityThreshold) {
         return similarityFunction.apply(comparison) >= similarityThreshold;
+    }
+
+    public String getDescription() {
+        return description;
     }
 
     @Override

--- a/jplag/src/main/java/de/jplag/reporting/jsonfactory/JsonFactory.java
+++ b/jplag/src/main/java/de/jplag/reporting/jsonfactory/JsonFactory.java
@@ -31,8 +31,8 @@ public class JsonFactory {
     public static List<String> getJsonStrings(JPlagReport jPlagReport) {
         List<String> jsonReports = new ArrayList<>();
         try {
-            jsonReports.add(mapper.writeValueAsString(jPlagReport.getOverviewReport()));
-            for (ComparisonReport comparisonReport : jPlagReport.getComparisons()) {
+            jsonReports.add(mapper.writeValueAsString(jPlagReport.overviewReport()));
+            for (ComparisonReport comparisonReport : jPlagReport.comparisons()) {
                 jsonReports.add(mapper.writeValueAsString(comparisonReport));
             }
         } catch (JsonProcessingException e) {
@@ -48,8 +48,8 @@ public class JsonFactory {
     public static boolean saveJsonFiles(JPlagReport jPlagReport, String folderPath) {
         try {
             ObjectMapper mapper = new ObjectMapper();
-            mapper.writeValue(Path.of(folderPath, "overview.json").toFile(), jPlagReport.getOverviewReport());
-            for (ComparisonReport report : jPlagReport.getComparisons()) {
+            mapper.writeValue(Path.of(folderPath, "overview.json").toFile(), jPlagReport.overviewReport());
+            for (ComparisonReport report : jPlagReport.comparisons()) {
                 String name = report.getFirstSubmissionId().concat("-").concat(report.getSecondSubmissionId()).concat(".json");
                 mapper.writeValue(Path.of(folderPath, name).toFile(), report);
             }

--- a/jplag/src/main/java/de/jplag/reporting/reportobject/ReportObjectFactory.java
+++ b/jplag/src/main/java/de/jplag/reporting/reportobject/ReportObjectFactory.java
@@ -6,12 +6,14 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.*;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import de.jplag.*;
+import de.jplag.options.SimilarityMetric;
 import de.jplag.reporting.reportobject.model.*;
 import de.jplag.reporting.reportobject.model.Match;
 
@@ -111,17 +113,39 @@ public class ReportObjectFactory {
         return names;
     }
 
-    // Currently, only one metric can be obtained.
-
     /**
-     * Gets the used metric in a JPlag comparison.
+     * Gets the used metrics in a JPlag comparison. As Max Metric is included in every JPlag run, this always include Max
+     * Metric.
      * @return A list contains Metric DTOs.
      */
     private static List<Metric> getMetrics(JPlagResult result) {
         List<Metric> metrics = new ArrayList<>();
-        metrics.add(new Metric(result.getOptions().getSimilarityMetric().name(), result.getOptions().getSimilarityThreshold(),
-                intArrayToList(result.getSimilarityDistribution()), getTopComparisons(result.getComparisons())));
+
+        Metric metric = new Metric(result.getOptions().getSimilarityMetric().name(), result.getOptions().getSimilarityThreshold(),
+                intArrayToList(result.getSimilarityDistribution()), getTopComparisons(result.getComparisons()),
+                result.getOptions().getSimilarityMetric().getDescription()); // get the metric JPlag was run with
+        metrics.add(metric);
+
+        if (result.getOptions().getSimilarityMetric() != SimilarityMetric.MAX) { // If JPlag was run with the max metric we do not need to calculate
+                                                                                 // nor add it separately as this has already happened in the run
+            var maxMetric = new Metric(SimilarityMetric.MAX.name(), result.getOptions().getSimilarityThreshold(),
+                    intArrayToList(result.getMaxMetricDistribution()), getMaxSimilarityTopComparisons(result.getComparisons()),
+                    SimilarityMetric.MAX.getDescription());
+            metrics.add(maxMetric);
+        }
+
         return metrics;
+    }
+
+    private static List<TopComparison> getMaxSimilarityTopComparisons(List<JPlagComparison> comparisons) {
+        return getTopComparisons(comparisons, JPlagComparison::maximalSimilarity);
+    }
+
+    private static List<TopComparison> getTopComparisons(List<JPlagComparison> comparisons, Function<JPlagComparison, Float> similarityExtractor) {
+        List<TopComparison> topComparisons = new ArrayList<>();
+        comparisons.forEach(comparison -> topComparisons.add(new TopComparison(comparison.getFirstSubmission().getName(),
+                comparison.getSecondSubmission().getName(), similarityExtractor.apply(comparison))));
+        return topComparisons;
     }
 
     /**
@@ -130,10 +154,7 @@ public class ReportObjectFactory {
      * @return List containing TopComparison DTOs.
      */
     private static List<TopComparison> getTopComparisons(List<JPlagComparison> comparisons) {
-        List<TopComparison> topComparisons = new ArrayList<>();
-        comparisons.forEach(comparison -> topComparisons.add(
-                new TopComparison(comparison.getFirstSubmission().getName(), comparison.getSecondSubmission().getName(), comparison.similarity())));
-        return topComparisons;
+        return getTopComparisons(comparisons, JPlagComparison::similarity);
     }
 
     /**

--- a/jplag/src/main/java/de/jplag/reporting/reportobject/model/JPlagReport.java
+++ b/jplag/src/main/java/de/jplag/reporting/reportobject/model/JPlagReport.java
@@ -2,20 +2,9 @@ package de.jplag.reporting.reportobject.model;
 
 import java.util.List;
 
-public class JPlagReport {
-    private final OverviewReport overviewReport;
-    private final List<ComparisonReport> comparisons;
-
+public record JPlagReport(OverviewReport overviewReport, List<ComparisonReport> comparisons) {
     public JPlagReport(OverviewReport overviewReport, List<ComparisonReport> comparisons) {
         this.overviewReport = overviewReport;
         this.comparisons = List.copyOf(comparisons);
-    }
-
-    public OverviewReport getOverviewReport() {
-        return overviewReport;
-    }
-
-    public List<ComparisonReport> getComparisons() {
-        return comparisons;
     }
 }

--- a/jplag/src/main/java/de/jplag/reporting/reportobject/model/Metric.java
+++ b/jplag/src/main/java/de/jplag/reporting/reportobject/model/Metric.java
@@ -4,40 +4,7 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class Metric {
-
-    @JsonProperty("name")
-    private final String name;
-
-    @JsonProperty("threshold")
-    private final float threshold;
-
-    @JsonProperty("distribution")
-    private final List<Integer> distribution;
-
-    @JsonProperty("topComparisons")
-    private final List<TopComparison> topComparisons;
-
-    public Metric(String name, float threshold, List<Integer> distribution, List<TopComparison> topComparisons) {
-        this.name = name;
-        this.threshold = threshold;
-        this.distribution = List.copyOf(distribution);
-        this.topComparisons = List.copyOf(topComparisons);
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public float getThreshold() {
-        return threshold;
-    }
-
-    public List<Integer> getDistribution() {
-        return distribution;
-    }
-
-    public List<TopComparison> getTopComparisons() {
-        return topComparisons;
-    }
+public record Metric(@JsonProperty("name") String name, @JsonProperty("threshold") float threshold,
+        @JsonProperty("distribution") List<Integer> distribution, @JsonProperty("topComparisons") List<TopComparison> topComparisons,
+        @JsonProperty String description) {
 }

--- a/jplag/src/main/resources/de/jplag/messages.properties
+++ b/jplag/src/main/resources/de/jplag/messages.properties
@@ -27,3 +27,5 @@ CommandLineArgument.ClusterPreprocessingNone=Do not use any preprocessing before
 CommandLineArgument.ClusterPreprocessingCdf=Before clustering, the value of the cumulative distribution function of all similarities is estimated. The similarities are multiplied with these estimates. This has the effect of supressing similarities that are low compared to other similarities.
 CommandLineArgument.ClusterPreprocessingPercentile=Any similarity smaller than the given percentile will be suppressed during clustering.
 CommandLineArgument.ClusterPreprocessingThreshold=Any similarity smaller than the given threshold value will be suppressed during clustering.
+SimilarityMetric.Avg.Description = Average of both program coverages. This is the default similarity which works in most cases: Matches with a high average similarity indicate that the programs work in a very similar way.
+SimilarityMetric.Max.Description = Defined as the maximum of both program coverages. This ranking is especially useful if the programs are very different in size. This can happen when dead code was inserted to disguise the origin of the plagiarized program.

--- a/jplag/src/main/resources/de/jplag/messages_de.properties
+++ b/jplag/src/main/resources/de/jplag/messages_de.properties
@@ -57,3 +57,6 @@ AllMatches.Distribution=Verteilung
 AllMatches.Length=L&auml;nge
 AllMatches.Number_of_matches=Anzahl der &Uuml;bereinstimmungen
 AllMatches.Basecode=Referenz&uuml;bereinstimmung
+
+SimilarityMetric.Avg.Description = Average of both program coverages. This is the default similarity which works in most cases: Matches with a high average similarity indicate that the programs work in a very similar way.
+SimilarityMetric.Max.Description = Defined as the maximum of both program coverages. This ranking is especially useful if the programs are very different in size. This can happen when dead code was inserted to disguise the origin of the plagiarized program.

--- a/jplag/src/main/resources/de/jplag/messages_en.properties
+++ b/jplag/src/main/resources/de/jplag/messages_en.properties
@@ -35,6 +35,7 @@ Report.HELP=HELP
 Report.Distribution=Distribution
 Report.Token_Distribution=Token Distribution
 
+
 Clusters.MIN_single_link=MIN, single link
 Clusters.AVR_group_average=AVR, group average
 Clusters.MAX_complete_link=MAX, complete link
@@ -57,3 +58,6 @@ AllMatches.Distribution=Distribution
 AllMatches.Length=Length
 AllMatches.Number_of_matches=No of matches
 AllMatches.Basecode=Basecode
+
+SimilarityMetric.Avg.Description = Average of both program coverages. This is the default similarity which works in most cases: Matches with a high average similarity indicate that the programs work in a very similar way.
+SimilarityMetric.Max.Description = Defined as the maximum of both program coverages. This ranking is especially useful if the programs are very different in size. This can happen when dead code was inserted to disguise the origin of the plagiarized program.

--- a/jplag/src/main/resources/de/jplag/messages_es.properties
+++ b/jplag/src/main/resources/de/jplag/messages_es.properties
@@ -57,3 +57,6 @@ AllMatches.Distribution=Distribución
 AllMatches.Length=Longitud
 AllMatches.Number_of_matches=No de coincidencias
 AllMatches.Basecode=Código Base
+
+SimilarityMetric.Avg.Description = Average of both program coverages. This is the default similarity which works in most cases: Matches with a high average similarity indicate that the programs work in a very similar way.
+SimilarityMetric.Max.Description = Defined as the maximum of both program coverages. This ranking is especially useful if the programs are very different in size. This can happen when dead code was inserted to disguise the origin of the plagiarized program.

--- a/jplag/src/main/resources/de/jplag/messages_fr.properties
+++ b/jplag/src/main/resources/de/jplag/messages_fr.properties
@@ -57,3 +57,6 @@ AllMatches.Distribution=Distribution
 AllMatches.Length=Length
 AllMatches.Number_of_matches=No of matches
 AllMatches.Basecode=Code source de reference
+
+SimilarityMetric.Avg.Description = Average of both program coverages. This is the default similarity which works in most cases: Matches with a high average similarity indicate that the programs work in a very similar way.
+SimilarityMetric.Max.Description = Defined as the maximum of both program coverages. This ranking is especially useful if the programs are very different in size. This can happen when dead code was inserted to disguise the origin of the plagiarized program.

--- a/jplag/src/main/resources/de/jplag/messages_pt.properties
+++ b/jplag/src/main/resources/de/jplag/messages_pt.properties
@@ -57,3 +57,6 @@ AllMatches.Distribution=Distribution
 AllMatches.Length=Length
 AllMatches.Number_of_matches=No of matches
 AllMatches.Basecode=Basecode
+
+SimilarityMetric.Avg.Description = Average of both program coverages. This is the default similarity which works in most cases: Matches with a high average similarity indicate that the programs work in a very similar way.
+SimilarityMetric.Max.Description = Defined as the maximum of both program coverages. This ranking is especially useful if the programs are very different in size. This can happen when dead code was inserted to disguise the origin of the plagiarized program.

--- a/report-viewer/package-lock.json
+++ b/report-viewer/package-lock.json
@@ -10761,6 +10761,12 @@
         "websocket-driver": "^0.7.4"
       }
     },
+    "node_modules/sortablejs": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.0.tgz",
+      "integrity": "sha512-bv9qgVMjUMf89wAvM6AxVvS/4MX3sPeN0+agqShejLU5z5GX4C75ow1O2e5k4L6XItUyAK3gH6AxSbXrOM5e8w==",
+      "peer": true
+    },
     "node_modules/source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -20563,6 +20569,12 @@
         "uuid": "^8.3.2",
         "websocket-driver": "^0.7.4"
       }
+    },
+    "sortablejs": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.0.tgz",
+      "integrity": "sha512-bv9qgVMjUMf89wAvM6AxVvS/4MX3sPeN0+agqShejLU5z5GX4C75ow1O2e5k4L6XItUyAK3gH6AxSbXrOM5e8w==",
+      "peer": true
     },
     "source-map": {
       "version": "0.5.7",

--- a/report-viewer/src/components/MetricButton.vue
+++ b/report-viewer/src/components/MetricButton.vue
@@ -3,41 +3,41 @@
   metric the distribution and comparisons are displayed.
 -->
 <template>
-  <div class="wrapper" v-bind:class="{ selected : isSelected }">
+  <div class="wrapper" v-bind:class="{ selected: isSelected }">
     <div class="metric">
-      <p class="metric-name">{{ metricName }}</p>
-      <img alt="?" src="@/assets/help_outline_black_18dp.svg"/>
+      <p class="metric-name">{{ metric.metricName }}</p>
+      <div class="tooltip">
+        <img alt="?" src="@/assets/help_outline_black_18dp.svg" />
+        <span class="tooltiptext">{{metric.description}}</span>
+      </div>
     </div>
     <div class="threshold">
-      <p>Threshold: </p>
-      <p>{{ metricThreshold }}%</p>
+      <p>Threshold:</p>
+      <p>{{ metric.metricThreshold }}%</p>
     </div>
   </div>
 </template>
 
-<script>
-import {defineComponent} from "vue";
+<script lang="ts">
+import { defineComponent, PropType } from "vue";
+import { Metric } from "@/model/Metric";
 
 export default defineComponent({
   name: "MetricButton",
   props: {
-    metricName: {
-      type: String,
-      required: true
-    },
-    metricThreshold: {
-      type: Number,
-      required: true
+    metric: {
+      type: Object as PropType<Metric>,
+      required: true,
     },
     isSelected: {
       type: Boolean,
-      default: false
+      default: false,
     },
   },
   setup() {
-    return {}
-  }
-})
+    return {};
+  },
+});
 </script>
 
 <style scoped>
@@ -50,7 +50,6 @@ export default defineComponent({
   padding: 5%;
   margin-right: 5%;
 }
-
 
 .wrapper > div > * {
   margin: 0;
@@ -89,5 +88,25 @@ export default defineComponent({
 
 .selected p {
   color: white;
+}
+.tooltip {
+  position: relative;
+  display: inline-block;
+}
+
+.tooltip .tooltiptext {
+  visibility: hidden;
+  width: 240px;
+  background-color: black;
+  color: #fff;
+  text-align: center;
+  padding: 10px ;
+  border-radius: 6px;
+  position: absolute;
+  z-index: 1;
+}
+
+.tooltip:hover .tooltiptext {
+  visibility: visible;
 }
 </style>

--- a/report-viewer/src/model/Metric.ts
+++ b/report-viewer/src/model/Metric.ts
@@ -5,6 +5,7 @@ import {ComparisonListElement} from "./ComparisonListElement";
  */
 export type Metric = {
     metricName: string,
+    description: string,
     metricThreshold: number,
     distribution: Array<number>,
     comparisons: Array<ComparisonListElement>

--- a/report-viewer/src/model/factories/OverviewFactory.ts
+++ b/report-viewer/src/model/factories/OverviewFactory.ts
@@ -1,67 +1,66 @@
-import {Overview} from "../Overview";
-import {Metric} from "../Metric";
-import {ComparisonListElement} from "../ComparisonListElement";
-import {Cluster} from "@/model/Cluster";
+import { Overview } from "../Overview";
+import { Metric } from "../Metric";
+import { ComparisonListElement } from "../ComparisonListElement";
+import { Cluster } from "@/model/Cluster";
 
 export class OverviewFactory {
+  static getOverview(json: Record<string, unknown>): Overview {
+    const submissionFolder = json.submission_folder_path as Array<string>;
+    const baseCodeFolder = "";
+    const language = json.language as string;
+    const fileExtensions = json.file_extensions as Array<string>;
+    const matchSensitivity = json.match_sensitivity as number;
+    const submissions = json.submission_ids as Array<string>;
+    const dateOfExecution = json.date_of_execution as string;
+    const duration = json.execution_time as number as number;
+    const metrics = [] as Array<Metric>;
+    const clusters = [] as Array<Cluster>;
+    (json.metrics as Array<unknown>).forEach((jsonMetric) => {
+      const metric = jsonMetric as Record<string, unknown>;
+      const comparisons = [] as Array<ComparisonListElement>;
 
-    static getOverview(json: Record<string, unknown>): Overview {
-        const submissionFolder = json.submission_folder_path as Array<string>
-        const baseCodeFolder = ""
-        const language = json.language as string
-        const fileExtensions = json.file_extensions as Array<string>
-        const matchSensitivity = json.match_sensitivity as number
-        const submissions = json.submission_ids as Array<string>
-        const dateOfExecution = json.date_of_execution as string
-        const duration = json.execution_time as number as number
-        const metrics = [] as Array<Metric>
-        const clusters = [] as Array<Cluster>
-        (json.metrics as Array<unknown>).forEach((jsonMetric) => {
-            const metric = jsonMetric as Record<string, unknown>
-            const comparisons = [] as Array<ComparisonListElement>
-
-            (metric.topComparisons as Array<Record<string, unknown>>).forEach(jsonComparison => {
-                const comparison: ComparisonListElement = {
-                    firstSubmissionId: jsonComparison.first_submission as string,
-                    secondSubmissionId: jsonComparison.second_submission as string,
-                    matchPercentage: jsonComparison.match_percentage as number
-                }
-                comparisons.push(comparison)
-            })
-
-            const newMetric: Metric = {
-                metricName: metric.name as string,
-                metricThreshold: metric.threshold as number,
-                distribution: metric.distribution as Array<number>,
-                comparisons: comparisons
-            }
-            metrics.push(newMetric)
-        });
-
-        if (json.clusters) {
-            (json.clusters as Array<unknown>).forEach(jsonCluster => {
-                const cluster = jsonCluster as Record<string, unknown>
-                const newCluster: Cluster = {
-                    averageSimilarity: cluster.average_similarity as number,
-                    strength: cluster.strength as number,
-                    members: cluster.members as Array<string>
-                }
-                clusters.push(newCluster)
-            })
+      (metric.topComparisons as Array<Record<string, unknown>>).forEach(
+        (jsonComparison) => {
+          const comparison: ComparisonListElement = {
+            firstSubmissionId: jsonComparison.first_submission as string,
+            secondSubmissionId: jsonComparison.second_submission as string,
+            matchPercentage: jsonComparison.match_percentage as number,
+          };
+          comparisons.push(comparison);
         }
+      );
+      metrics.push({
+        metricName: metric.name as string,
+        metricThreshold: metric.threshold as number,
+        distribution: metric.distribution as Array<number>,
+        comparisons: comparisons,
+        description: metric.description as string
+      });
+    });
 
-
-        return new Overview(
-            submissionFolder,
-            baseCodeFolder,
-            language,
-            fileExtensions,
-            matchSensitivity,
-            submissions,
-            dateOfExecution,
-            duration,
-            metrics,
-            clusters
-        )
+    if (json.clusters) {
+      (json.clusters as Array<unknown>).forEach((jsonCluster) => {
+        const cluster = jsonCluster as Record<string, unknown>;
+        const newCluster: Cluster = {
+          averageSimilarity: cluster.average_similarity as number,
+          strength: cluster.strength as number,
+          members: cluster.members as Array<string>,
+        };
+        clusters.push(newCluster);
+      });
     }
+
+    return new Overview(
+      submissionFolder,
+      baseCodeFolder,
+      language,
+      fileExtensions,
+      matchSensitivity,
+      submissions,
+      dateOfExecution,
+      duration,
+      metrics,
+      clusters
+    );
+  }
 }

--- a/report-viewer/src/views/OverviewView.vue
+++ b/report-viewer/src/views/OverviewView.vue
@@ -64,8 +64,7 @@
             :id="metric.metricName"
             :key="metric.metricName"
             :is-selected="selectedMetric[index]"
-            :metric-name="metric.metricName"
-            :metric-threshold="metric.metricThreshold"
+            :metric="metric"
             @click="selectMetric(index)"
           />
         </div>


### PR DESCRIPTION
Max Metric is now included in Webreport DTO.
In Webreport the user can switch between between multiple metrics:
If JPlag was run with a metric other than the max metric, e.g. avg metric,
the user will be able to rank comparisons in the WebReport by the
max metric additionally,
If JPlag was run with the max metric, this is the only metric available.